### PR TITLE
fix: launcher icon background color

### DIFF
--- a/app/src/main/res/values/ic_launcher_background.xml
+++ b/app/src/main/res/values/ic_launcher_background.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="ic_launcher_background">#FFFFFF</color>
+    <color name="ic_launcher_background">#EFF1F5</color>
 </resources>


### PR DESCRIPTION
Just noticed while doing the icon update PR for ClockYou, that you had to change the background color, because it was dark. However it's full white now, but it should be "EFF1F5". That's the color we picked from the Catppuccin palette for all the icons. https://github.com/catppuccin/catppuccin/blob/main/assets/palette/circles/latte_base.png